### PR TITLE
Enable auto-update for RVM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,41 +26,45 @@ ARG RVM_VERSION=stable
 ENV RVM_VERSION=${RVM_VERSION}
 
 # RMV user to create
+# Optional: child images can change to this user, or add 'rvm' group to other user
 ARG RVM_USER=rvm
 ENV RVM_USER=${RVM_USER}
 
-# Install RVM
-RUN apt update \
-    && apt install -y \
+# Install RVM dependencies
+RUN sed -i 's/^mesg n/tty -s \&\& mesg n/g' ~/.profile \
+ && sed -i 's~http://archive\(\.ubuntu\.com\)/ubuntu/~mirror://mirrors\1/mirrors.txt~g' /etc/apt/sources.list \
+ && export DEBIAN_FRONTEND=noninteractive \
+ && apt-get update -qq \
+ && apt-get install -qy --no-install-recommends \
+       ca-certificates \
+ && apt-get install -qy --no-install-recommends \
        curl \
+       dirmngr \
        git \
        gnupg2 \
-    && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/*
 
 # Install + verify RVM with gpg (https://rvm.io/rvm/security)
-RUN gpg2 --quiet --no-tty --logger-fd 1 --keyserver hkp://keys.gnupg.net \
+RUN mkdir ~/.gnupg \
+ && chmod 700 ~/.gnupg \
+ && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
+ && gpg2 --quiet --no-tty --keyserver hkp://pool.sks-keyservers.net \
          --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 \
                      7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
-    && echo 409B6B1796C275462A1703113804BB82D39DC0E3:6: | \
-       gpg2 --quiet --no-tty --logger-fd 1 --import-ownertrust \
-    && curl -sSO https://raw.githubusercontent.com/rvm/rvm/${RVM_VERSION}/binscripts/rvm-installer \
-    && curl -sSO https://raw.githubusercontent.com/rvm/rvm/${RVM_VERSION}/binscripts/rvm-installer.asc \
-    && gpg2 --quiet --no-tty --logger-fd 1 --verify rvm-installer.asc \
-    && bash rvm-installer ${RVM_VERSION} \
-    && rm rvm-installer rvm-installer.asc \
-    && echo "bundler" >> /usr/local/rvm/gemsets/global.gems \
-    && echo "rvm_silence_path_mismatch_check_flag=1" >> /etc/rvmrc \
-    && echo "install: --no-document" > /etc/gemrc
-
-# Workaround tty check, see https://github.com/hashicorp/vagrant/issues/1673#issuecomment-26650102
-RUN sed -i 's/^mesg n/tty -s \&\& mesg n/g' /root/.profile
+ && ( echo 409B6B1796C275462A1703113804BB82D39DC0E3:6: | gpg2 --import-ownertrust ) \
+ && ( echo 7D2BAF1CF37B13E2069D6956105BD0E739499BDB:6: | gpg2 --import-ownertrust ) \
+ && curl -sSL https://raw.githubusercontent.com/rvm/rvm/${RVM_VERSION}/binscripts/rvm-installer -o rvm-installer \
+ && curl -sSL https://raw.githubusercontent.com/rvm/rvm/${RVM_VERSION}/binscripts/rvm-installer.asc -o rvm-installer.asc \
+ && gpg2 --verify rvm-installer.asc rvm-installer \
+ && bash rvm-installer \
+ && rm rvm-installer \
+ && echo "rvm_autoupdate_flag=2" >> /etc/rvmrc \
+ && echo "rvm_silence_path_mismatch_check_flag=1" >> /etc/rvmrc \
+ && echo "install: --no-document" > /etc/gemrc \
+ && useradd -m --no-log-init -r -g rvm ${RVM_USER}
 
 # Switch to a bash login shell to allow simple 'rvm' in RUN commands
 SHELL ["/bin/bash", "-l", "-c"]
-
-# Optional: child images can change to this user, or add 'rvm' group to other user
-# see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
-RUN useradd -m --no-log-init -r -g rvm ${RVM_USER}
 
 # Optional: child images can set Ruby versions to install (whitespace-separated)
 ONBUILD ARG RVM_RUBY_VERSIONS
@@ -70,14 +74,14 @@ ONBUILD ARG RVM_RUBY_DEFAULT
 
 # Child image runs this only if RVM_RUBY_VERSIONS is defined as ARG before the FROM line
 ONBUILD RUN if [ ! -z "${RVM_RUBY_VERSIONS}" ]; then \
-              VERSIONS="$(echo "${RVM_RUBY_VERSIONS}" | sed -E -e 's/\s+/\n/g')" \
-              && for v in ${VERSIONS}; do \
-                   echo "== docker-rvm: Installing ${v} ==" \
-                   && rvm install ${v}; \
-                 done \
-              && DEFAULT=${RVM_RUBY_DEFAULT:-$(echo "${VERSIONS}" | head -n1)} \
-              && echo "== docker-rvm: Setting default ${DEFAULT} ==" \
-              && rvm use --default "${DEFAULT}"; \
-            fi \
-            && rvm cleanup all \
-            && rm -rf /var/lib/apt/lists/*
+              for v in $( echo ${RVM_RUBY_VERSIONS} | sed -E 's/[[:space:]]+/\n/g' ); do \
+                echo "== docker-rvm: Installing ${v} ==" \
+                && rvm install ${v}; \
+              done \
+              && echo "== docker-rvm: Setting default ${RVM_RUBY_DEFAULT} ==" \
+              && rvm use --default ${RVM_RUBY_DEFAULT:-${RVM_RUBY_VERSIONS/[[:space:]]*/}} \
+              && rvm cleanup all \
+              && rm -rf /var/lib/apt/lists/*; \
+            fi
+
+CMD ["/bin/bash", "-l"]


### PR DESCRIPTION
  - Remove duplicated `bundler` from global gem
  - Enable auto-update for RVM by using `rvm_autoupdate_flag`
  - Speed up `apt` packages installing with `mirror` sources list
  - Remove unnecessary `apt` packages with `--no-install-recommends` switch
  - Install RVM with official installer command
  - Optimize `ONBUILD` script to install specified Ruby versions

Thanks @nthachus for the original PR this is based on:
  - https://github.com/ms-ati/docker-rvm/pull/2